### PR TITLE
Correction de l'apparence des combobox, chevron à droite (css)

### DIFF
--- a/display/CSS/bootstrap-prototypephp.css
+++ b/display/CSS/bootstrap-prototypephp.css
@@ -112,6 +112,22 @@ legend {
 	background-repeat: no-repeat;
 	background-position: 100% 50%;
 }
+/* Ajouts pour le composant combobox */
+.ui-state-default, .ui-button {
+	background: white;
+}
+.custom-combobox {
+	position: relative;
+	display: inline-block;
+	width:100%;
+}
+.custom-combobox-toggle {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	padding: 0;
+	right: -1px;
+}
 /* Espacement entre deux lignes */
 .top5 { margin-top:5em; }
 .top10 { margin-top:10em; }


### PR DESCRIPTION
dans bootstrap-prototypephp.css
![collec labo chrono dev](https://user-images.githubusercontent.com/26461464/37407845-08525698-279b-11e8-9a7e-c1a106174403.png)
