### PR TITLE
Support connexion à Active Directory avec User Principal Name (UPN)

### DIFF
--- a/framework/common.inc.php
+++ b/framework/common.inc.php
@@ -124,7 +124,7 @@ if ($ident_type == "CAS") {
     require_once "vendor/jasig/phpcas/CAS.php";
 	$identification->init_CAS ( $CAS_address, $CAS_port, $APPLI_address );
 } elseif ($ident_type == "LDAP" || $ident_type == "LDAP-BDD") {
-	$identification->init_LDAP ( $LDAP["address"], $LDAP["port"], $LDAP["basedn"], $LDAP["user_attrib"], $LDAP["v3"], $LDAP["tls"] );
+	$identification->init_LDAP ( $LDAP["address"], $LDAP["port"], $LDAP["basedn"], $LDAP["user_attrib"], $LDAP["upn_suffix"], $LDAP["v3"], $LDAP["tls"] );
 }
 /*
  * Chargement des fonction generiques

--- a/framework/common.inc.php
+++ b/framework/common.inc.php
@@ -124,7 +124,7 @@ if ($ident_type == "CAS") {
     require_once "vendor/jasig/phpcas/CAS.php";
 	$identification->init_CAS ( $CAS_address, $CAS_port, $APPLI_address );
 } elseif ($ident_type == "LDAP" || $ident_type == "LDAP-BDD") {
-	$identification->init_LDAP ( $LDAP["address"], $LDAP["port"], $LDAP["basedn"], $LDAP["user_attrib"], $LDAP["upn_suffix"], $LDAP["v3"], $LDAP["tls"] );
+	$identification->init_LDAP ( $LDAP["address"], $LDAP["port"], $LDAP["basedn"], $LDAP["user_attrib"], $LDAP["v3"], $LDAP["tls"], $LDAP["upn_suffix"] );
 }
 /*
  * Chargement des fonction generiques

--- a/framework/droits/droits.class.php
+++ b/framework/droits/droits.class.php
@@ -385,6 +385,8 @@ class Aclgroup extends ObjetBDD
         if ($ldapParam["groupSupport"]) {
             /*
              * Recuperation des attributs depuis l'annuaire LDAP
+             * Attention : interroge l'annuaire en mode anonyme 
+             -             et donc echoue si l'annuaire requiere un login/mot de passe pour une recherche
              */
             include_once "framework/ldap/ldap.class.php";
             $ldap = new Ldap($ldapParam["address"], $ldapParam["basedn"]);
@@ -395,7 +397,11 @@ class Aclgroup extends ObjetBDD
                     $ldapParam["mailAttrib"],
                     $ldapParam["groupAttrib"]
                 );
-                $filtre = "(" . $ldapParam["user_attrib"] . "=" . $_SESSION["login"] . ")";
+                $filtre = "(" . $ldapParam["user_attrib"] . "=" . $_SESSION["login"] . ")"; // Attention...
+                /* 
+                 * Attention : ne gere pas le cas de user_attrib vide lors d'une connexion a un Active Directory
+                 *             avec le userPrincipalName (et eventuellement l'UPN Suffix defini)
+                 */
                 $dataLdap = $ldap->getAttributs($ldapParam["basedngroup"], $filtre, $attribut);
                 if ($dataLdap["count"] > 0) {
                     $_SESSION["loginNom"] = $dataLdap[0][$ldapParam["commonNameAttrib"]][0];

--- a/framework/identification/identification.class.php
+++ b/framework/identification/identification.class.php
@@ -38,11 +38,11 @@ class Identification
 
     var $LDAP_user_attrib;
 
-    var $LDAP_upn_suffix; // User Principal Name (UPN) Suffix pour Active Directory
-
     var $LDAP_v3;
 
     var $LDAP_tls;
+
+    var $LDAP_upn_suffix; // User Principal Name (UPN) Suffix pour Active Directory
 
     var $password;
 
@@ -97,19 +97,19 @@ class Identification
      * @param String $LDAP_port
      * @param String $LDAP_basedn
      * @param String $LDAP_user_attrib
-     * @param String $LDAP_upn_suffix
      * @param String $LDAP_v3
      * @param String $LDAP_tls
+     * @param String $LDAP_upn_suffix
      */
-    function init_LDAP($LDAP_address, $LDAP_port, $LDAP_basedn, $LDAP_user_attrib, $LDAP_upn_suffix, $LDAP_v3, $LDAP_tls)
+    function init_LDAP($LDAP_address, $LDAP_port, $LDAP_basedn, $LDAP_user_attrib, $LDAP_v3, $LDAP_tls, $LDAP_upn_suffix="" )
     {
         $this->LDAP_address = $LDAP_address;
         $this->LDAP_port = $LDAP_port;
         $this->LDAP_basedn = $LDAP_basedn;
         $this->LDAP_user_attrib = $LDAP_user_attrib;
-        $this->LDAP_upn_suffix = $LDAP_upn_suffix;
         $this->LDAP_v3 = $LDAP_v3;
         $this->LDAP_tls = $LDAP_tls;
+        $this->LDAP_upn_suffix = $LDAP_upn_suffix;
     }
 
     /**

--- a/framework/ldap/ldap.class.php
+++ b/framework/ldap/ldap.class.php
@@ -56,14 +56,6 @@ class Ldap
     var $LDAP_user_attrib;
 
     /**
-     * Attribut ldap contenant le suffixe de l'UPN (User Principal Name)
-     * de la forme <sAMAccountName>@<UPN Suffix> pour Active Directory
-     * 
-     * @var string
-     */
-    var $LDAP_upn_suffix;
-
-    /**
      * Version de l'annuaire
      * 
      * @var boolean
@@ -76,6 +68,14 @@ class Ldap
      * @var boolean
      */
     var $LDAP_tls;
+
+    /**
+     * Attribut ldap contenant le suffixe de l'UPN (User Principal Name)
+     * de la forme <sAMAccountName>@<UPN Suffix> pour Active Directory
+     * 
+     * @var string
+     */
+    var $LDAP_upn_suffix;
 
     /**
      * Identifiant de connexion de l'annuaire ldap
@@ -98,20 +98,20 @@ class Ldap
      * @param string $LDAP_basedn
      * @param int $LDAP_port
      * @param string $LDAP_user_attrib
-     * @param string $LDAP_upn_suffix
      * @param boolean $LDAP_v3
      * @param boolean $LDAP_tls
+     * @param string $LDAP_upn_suffix
      * @return void;
      */
-    function __construct($LDAP_address, $LDAP_basedn, $LDAP_port = 389, $LDAP_user_attrib = "uid", $LDAP_upn_suffix = "", $LDAP_v3 = 1, $LDAP_tls = 0)
+    function __construct($LDAP_address, $LDAP_basedn, $LDAP_port = 389, $LDAP_user_attrib = "uid", $LDAP_v3 = 1, $LDAP_tls = 0, $LDAP_upn_suffix = "")
     {
         $this->LDAP_address = $LDAP_address;
         $this->LDAP_port = $LDAP_port;
         $this->LDAP_basedn = $LDAP_basedn;
         $this->LDAP_user_attrib = $LDAP_user_attrib;
-        $this->LDAP_upn_suffix = $LDAP_upn_suffix;
         $this->LDAP_v3 = $LDAP_v3;
         $this->LDAP_tls = $LDAP_tls;
+        $this->LDAP_upn_suffix = $LDAP_upn_suffix;
     }
 
     /**

--- a/param/param.default.inc.php
+++ b/param/param.default.inc.php
@@ -56,6 +56,7 @@ $LDAP = array(
 		"rdn" => "cn=manager,dc=example,dc=com",
 		"basedn" => "ou=people,ou=example,o=societe,c=fr",
 		"user_attrib" => "uid",
+		"upn_suffix" => "", //pour Active Directory
 		"v3" => true,
 		"tls" => false,
 		"groupSupport"=>false,

--- a/param/param.default.inc.php
+++ b/param/param.default.inc.php
@@ -56,9 +56,9 @@ $LDAP = array(
 		"rdn" => "cn=manager,dc=example,dc=com",
 		"basedn" => "ou=people,ou=example,o=societe,c=fr",
 		"user_attrib" => "uid",
-		"upn_suffix" => "", //pour Active Directory
 		"v3" => true,
 		"tls" => false,
+		"upn_suffix" => "", //pour Active Directory
 		"groupSupport"=>false,
 		"groupAttrib"=>"supannentiteaffectation",
 		"commonNameAttrib"=>"displayname",

--- a/param/param.inc.php.dist
+++ b/param/param.inc.php.dist
@@ -108,6 +108,8 @@ $LDAP [ "user_attrib" ] = "uid";
  * avec le User Principal Name (UPN) de la forme sAMAccountName@UPN_Suffix
  * pour ne demander que le sAMAccountName à l'utilisateur
  * alors définir le upn_suffix en décommentant les lignes ci-dessous
+ * pour demander l'UPN entier à l'utilisateur
+ * alors définir le upn_suffix à une chaîne vide : $LDAP [ "upn_suffix"] = "";
  */
 //$LDAP [ "basedn"] = ""; 
 //$LDAP [ "user_attrib" ] = "";

--- a/param/param.inc.php.dist
+++ b/param/param.inc.php.dist
@@ -103,6 +103,16 @@ $LDAP [ "tls"] = true;
  */
 $LDAP [ "basedn"] = "ou=people,ou=example,o=societe,c=fr";
 $LDAP [ "user_attrib" ] = "uid";
+/* 
+ * Pour une authentification LDAP à un Active Directory
+ * avec le User Principal Name (UPN) de la forme sAMAccountName@UPN_Suffix
+ * pour ne demander que le sAMAccountName à l'utilisateur
+ * alors définir le upn_suffix en décommentant les lignes ci-dessous
+ */
+//$LDAP [ "basedn"] = ""; 
+//$LDAP [ "user_attrib" ] = "";
+//$LDAP [ "upn_suffix"] = "mydomain.lan";
+
 
 /*
  * Recherche des groupes dans l'annuaire LDAP


### PR DESCRIPTION
Supporte la connexion à un Active Directory avec le User Principal Name (UPN) de la forme : sAMAccountName@UPN_Suffix
Possibilité de se loguer uniquement avec le sAMAccountName en définissant dans les paramètres le UPN_Suffix