### PR TITLE
Correction de l'export pour les étiquettes externes

### DIFF
--- a/modules/classes/object.class.php
+++ b/modules/classes/object.class.php
@@ -180,8 +180,19 @@ class Object extends ObjetBDD
                  */
                 $metadata = json_decode($value["metadata"], true);
                 foreach ($metadata as $kmd => $md) {
-                    $data[$key][$kmd] = $md;
+                    if (is_array($md)) {
+                        $val = "";
+                        $comma = "";
+                        foreach($md as $v) {
+                            $val .= $comma.$v;
+                            $comma = ", ";
+                        }
+                    } else {
+                        $val = $md;
+                    }
+                    $data[$key][$kmd] = $val;
                 }
+                unset ($data[$key]["metadata"]);
                 /*
                  * Recuperation de la liste des identifiants externes
                  */


### PR DESCRIPTION
Si les métadonnées contenaient plusieurs valeurs, elles n'étaient pas
correctement écrites dans le fichier
Effacement de la colonne metadata, inutile.
Correction du bug #170 