### PR TITLE
#UI permet de revenir à l'accueil avec le premier item du menu

### DIFF
--- a/display/templates/entete.tpl
+++ b/display/templates/entete.tpl
@@ -9,7 +9,7 @@
 					class="icon-bar"></span>
 			</button>
 			<div class="navbar-brand"><img src="{$favicon}" height="25"></div>
-			<span class="navbar-text hidden-xs hidden-sm"><b>{$APPLI_titre}</b></span>
+			<a href='/'><span class="navbar-text hidden-xs hidden-sm"><b>{$APPLI_titre}</b></span></a>
 		</div>
 		<!-- Affichage du menu -->
 		<div class="collapse navbar-collapse" id="navbar_collapse">


### PR DESCRIPTION
Plusieurs utilisateurs sont tentés de revenir à l'écran d'accueil de l'appli en cliquant sur le premier item du menu