### PR TITLE
Version de ObjetBDD avec gettext ?

### DIFF
--- a/plugins/objetBDD-3.5/ObjetBDD_functions.php
+++ b/plugins/objetBDD-3.5/ObjetBDD_functions.php
@@ -5,19 +5,10 @@
  * 18 aout 2009
  */
 function objetBDDparamInit() {
-    global $ObjetBDDParam, $DEFAULT_formatdate, $OBJETBDD_debugmode, $LANG,  $FORMATDATE;
+    global $ObjetBDDParam, $DEFAULT_formatdate, $OBJETBDD_debugmode, $FORMATDATE;
 if(!isset($DEFAULT_formatdate)) $DEFAULT_formatdate = "fr";
 if (!isset($OBJETBDD_debugmode)) $OBJETBDD_debugmode = 1;
-if (!isset($LANG)) {
-	$LANG["ObjetBDDError"][0] = "Le champ ";
-	$LANG["ObjetBDDError"][1] = " n'est pas numerique.";
-	$LANG["ObjetBDDError"][2] = " est trop grand. Longueur maximale autorisée : ";
-	$LANG["ObjetBDDError"][3] = " Valeur saisie : ";
-	$LANG["ObjetBDDError"][4] = " caractères";
-	$LANG["ObjetBDDError"][5] = "Le contenu du champ ";
-	$LANG["ObjetBDDError"][6] = " ne correspond pas au format attendu. Masque autorisé : ";
-	$LANG["ObjetBDDError"][7] = " est obligatoire, mais n'a pas été renseigné.";
-}
+
 /**
  * Preparation des parametres pour les classes heritees de ObjetBDD
  */
@@ -67,29 +58,33 @@ function _ecrire($instance,$data) {
 /**
  * function formatErrorData
  * Formate les erreurs d'analyse des donnees avant mise en fichier,
- * en tenant compte des parametres de langue
+ * en utilisant la solution gettext (alias _()) pour la traduction.
+ * Le paramétrage de gettext et les traductions restent à faire en dehors de ce plugin.
  * @param $data
  * @return unknown_type
  */
 function formatErrorData($data) {
-	$LANG = & $GLOBALS['LANG'];
 	$res = "";
 	foreach ($data as $key => $value) {
 		$data[$key]["valeur"] = htmlentities($data[$key]["valeur"]);
 		if ($data[$key]["code"]==0) {
 			$res .= $data[$key]["message"]."<br>";
 		}elseif ($data[$key]["code"]==1) {
-			$res .= $LANG["ObjetBDDError"][0].$data[$key]["colonne"].$LANG["ObjetBDDError"][1].$LANG["ObjetBDDError"][3].
-			$data[$key]["valeur"]."<br>";
+			// traduction: bien conserver inchangées les chaînes %1$s, %2$s...
+			$res .= sprintf(_('Le champ %1$s n\'est pas numérique. Valeur saisie : %2$s'),
+				                        $data[$key]["colonne"],                   $data[$key]["valeur"])."<br>";
 		}elseif ($data[$key]["code"]==2) {
-			$res .= $LANG["ObjetBDDError"][0].$data[$key]["colonne"].$LANG["ObjetBDDError"][2].
-			$data[$key]["demande"].$LANG["ObjetBDDError"][3].$data[$key]["valeur"].
-					" (".strlen($data[$key]["valeur"]).$LANG["ObjetBDDError"][4].")<br>";
+			// traduction: bien conserver inchangées les chaînes %1$s, %2$s...
+			$res .= sprintf(_('Le champ %1$s est trop grand. Longueur maximale autorisée : %2$s Valeur saisie : %3$s (%4$s caractères)'),
+				                       $data[$key]["colonne"],$data[$key]["demande"],$data[$key]["valeur"],strlen($data[$key]["valeur"]))."<br>"; 
 		}elseif ($data[$key]["code"]==3) {
-			$res .= $LANG["ObjetBDDError"][5].$data[$key]["colonne"].$LANG["ObjetBDDError"][6].
-			$data[$key]["demande"].$LANG["ObjetBDDError"][3].$data[$key]["valeur"]."<br>";
+			// traduction: bien conserver inchangées les chaînes %1$s, %2$s...
+			$res .= sprintf(_('Le contenu du champ %1$s ne correspond pas au format attendu. Masque autorisé : %2$s Valeur saisie : %3$s'),
+				                                    $data[$key]["colonne"],                $data[$key]["demande"],$data[$key]["valeur"])."<br>"; 
 		}elseif ($data[$key]["code"]==4) {
-			$res .= "Le champ ".$data[$key]["colonne"].$LANG["ObjetBDDError"][7]."<br>";
+			// traduction: bien conserver inchangées les chaînes %1$s, %2$s...
+			$res .= sprintf(_('Le champ %1$s est obligatoire, mais n\'a pas été renseigné.'),
+				                        $data[$key]["colonne"])."<br>"; 
 		}
 	}
 	return $res;


### PR DESCRIPTION
Voici ce que donnerait une version de ObjetBDD avec gettext à la place de $LANG.
Code non testé.
Devrait être rétrocompatible (sauf avec les traductions déjà faites avec $LANG); gettext est dans PHP 4/5/7.
Le paramétrage de gettext et les traductions seraient à faire en dehors de ce plugin pour chaque application qui l'utilise. Une traduction .po (à intégrer par le développeur dans le .mo vraiment utilisé par l'application) pourrait tout de même être fournie.
A voir si cela est pertinent. (Collec n'utilise d'ailleurs pas formatErrorData())